### PR TITLE
Add clap args for main binary

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -1,0 +1,24 @@
+use std::net::{SocketAddr, ToSocketAddrs};
+
+use anyhow::Context;
+use clap::Parser;
+
+#[derive(Parser, Debug)]
+#[command(author, version, about)]
+pub struct Args {
+    /// IP address
+    #[clap(
+        short,
+        long,
+        default_value = "localhost:8000",
+        value_parser(resolve_address)
+    )]
+    pub address: SocketAddr,
+}
+
+fn resolve_address(address: &str) -> Result<SocketAddr, anyhow::Error> {
+    address
+        .to_socket_addrs()
+        .map(|mut v| v.next().expect("No address parsed"))
+        .with_context(|| format!("Failed to parse socket address {address}"))
+}

--- a/src/db/schema.rs
+++ b/src/db/schema.rs
@@ -16,4 +16,7 @@ diesel::table! {
     }
 }
 
-diesel::allow_tables_to_appear_in_same_query!(shopping_items, users,);
+diesel::allow_tables_to_appear_in_same_query!(
+    shopping_items,
+    users,
+);

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,6 @@
 use actix_web::{middleware::Logger, App, HttpServer};
+use args::Args;
+use clap::Parser;
 use wg_page_backend::api::{
     shopping_items::{
         create_shopping_item, delete_shopping_item, get_all_shopping_items, get_shopping_item,
@@ -7,9 +9,16 @@ use wg_page_backend::api::{
     user::{create_user, delete_user, get_all_users, get_user, update_user},
 };
 
+mod args;
+
 #[actix_web::main]
 async fn main() -> std::io::Result<()> {
     env_logger::init();
+
+    let args = Args::parse();
+    let address = args.address;
+
+    log::info!("Starting server at {address}");
 
     HttpServer::new(move || {
         let logger = Logger::default();
@@ -27,7 +36,7 @@ async fn main() -> std::io::Result<()> {
             .service(update_shopping_item)
             .service(delete_shopping_item)
     })
-    .bind(("127.0.0.1", 8000))?
+    .bind(address)?
     .run()
     .await
 }


### PR DESCRIPTION
Set socket address for server to spawn.
The passed address is validated, then resolved, so you could pass for example `localhost:8080`.
Default value is `127.0.0.1:8000` as it was before, but it may be resolved to sth. like `[::1]:8000`.